### PR TITLE
Add SQLite3-backed ActiveRecord model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source :rubygems
 
+gem 'activerecord'
+gem 'sqlite3'
+
 group :test do
   gem 'rake'
   gem 'rspec', '~> 2.8.0'

--- a/lib/ruby_warrior.rb
+++ b/lib/ruby_warrior.rb
@@ -18,6 +18,7 @@ require 'ruby_warrior/floor'
 require 'ruby_warrior/space'
 require 'ruby_warrior/position'
 require 'ruby_warrior/logger'
+require 'ruby_warrior/decree'
 
 require 'ruby_warrior/units/base'
 require 'ruby_warrior/units/warrior'

--- a/lib/ruby_warrior.rb
+++ b/lib/ruby_warrior.rb
@@ -18,7 +18,7 @@ require 'ruby_warrior/floor'
 require 'ruby_warrior/space'
 require 'ruby_warrior/position'
 require 'ruby_warrior/logger'
-require 'ruby_warrior/decree'
+require 'ruby_warrior/note'
 
 require 'ruby_warrior/units/base'
 require 'ruby_warrior/units/warrior'

--- a/lib/ruby_warrior/abilities/talk.rb
+++ b/lib/ruby_warrior/abilities/talk.rb
@@ -19,7 +19,7 @@ module RubyWarrior
         if receiver
           @unit.say "faces #{direction} and talks to #{receiver}"
           if receiver.to_s == "Informant"
-            @unit.gather_info(receiver.answer)
+            receiver.answer
           else
             @unit.say "but #{receiver} says nothing"
           end

--- a/lib/ruby_warrior/decree.rb
+++ b/lib/ruby_warrior/decree.rb
@@ -1,0 +1,10 @@
+require 'active_record'
+
+module RubyWarrior
+  class Decree < ActiveRecord::Base
+    establish_connection adapter: "sqlite3", database: "warriors/foobar.db"
+    connection.create_table table_name, force: true do |t|
+      t.string :body
+    end
+  end
+end

--- a/lib/ruby_warrior/note.rb
+++ b/lib/ruby_warrior/note.rb
@@ -1,9 +1,9 @@
 require 'active_record'
 
 module RubyWarrior
-  class Decree < ActiveRecord::Base
+  class Note < ActiveRecord::Base
     establish_connection adapter: "sqlite3", database: "warriors/foobar.db"
-    connection.create_table table_name, force: true do |t|
+    connection.create_table table_name, if_not_exists: true do |t|
       t.string :body
     end
   end

--- a/towers/clio/level_001.rb
+++ b/towers/clio/level_001.rb
@@ -34,7 +34,7 @@ size 12, 7
 stairs 11, 3
 
 warrior 0, 0, :east do |u|
-  u.add_abilities :walk!, :attack!, :health, :rest!, :rescue!, :bind!, :listen, :direction_of, :feel, :direction_of_stairs, :distance_of, :detonate!, :look, :talk!
+  u.add_abilities :walk!, :attack!, :health, :rest!, :rescue!, :bind!, :listen, :direction_of, :feel, :direction_of_stairs, :distance_of, :detonate!, :look, :talk
 end
 
 unit :informant, 8, 1, :west do |u|


### PR DESCRIPTION
Notes:
 - SQLite3's backend adapter required a minimum Ruby version of `2.7`. So far using `2.7.7` instead of `2.6.10` hasn't broken anything locally for me, though I haven't tested deeply
 - Make sure to use `bundle exec ruby rubywarrior -d warriors` instead of just `ruby rubywarrior -d warriors` after using `bundle install`, especially if you installed the gems to a local `vendor` folder or similar