### PR TITLE
Fix level 4 definition + tweak db script

### DIFF
--- a/lib/ruby_warrior/note.rb
+++ b/lib/ruby_warrior/note.rb
@@ -5,7 +5,7 @@ module RubyWarrior
     establish_connection adapter: "sqlite3", database: "warriors/map_survey.db"
     connection.create_table :notes, if_not_exists: true do |t|
       t.column :level_number, :int, limit: 3, :null => false
-      t.column :type, :string, limit: 20, :null => false
+      t.column :unit_type, :string, limit: 20, :null => false
       t.column :x, :int, limit:3, :null => false
       t.column :y, :int, limit:3, :null => false
     end

--- a/lib/ruby_warrior/note.rb
+++ b/lib/ruby_warrior/note.rb
@@ -2,9 +2,12 @@ require 'active_record'
 
 module RubyWarrior
   class Note < ActiveRecord::Base
-    establish_connection adapter: "sqlite3", database: "warriors/foobar.db"
-    connection.create_table table_name, if_not_exists: true do |t|
-      t.string :body
+    establish_connection adapter: "sqlite3", database: "warriors/map_survey.db"
+    connection.create_table :map_items, if_not_exists: true do |t|
+      t.column :level_number, :int, limit: 3, :null => false
+      t.column :type, :string, limit: 20, :null => false
+      t.column :x, :int, limit:3, :null => false
+      t.column :y, :int, limit:3, :null => false
     end
   end
 end

--- a/lib/ruby_warrior/note.rb
+++ b/lib/ruby_warrior/note.rb
@@ -3,7 +3,7 @@ require 'active_record'
 module RubyWarrior
   class Note < ActiveRecord::Base
     establish_connection adapter: "sqlite3", database: "warriors/map_survey.db"
-    connection.create_table :map_items, if_not_exists: true do |t|
+    connection.create_table :notes, if_not_exists: true do |t|
       t.column :level_number, :int, limit: 3, :null => false
       t.column :type, :string, limit: 20, :null => false
       t.column :x, :int, limit:3, :null => false

--- a/lib/ruby_warrior/note.rb
+++ b/lib/ruby_warrior/note.rb
@@ -2,10 +2,11 @@ require 'active_record'
 
 module RubyWarrior
   class Note < ActiveRecord::Base
+    enum unit_type: ["archer", "bug", "captive" "guard", "informant", "queen_bug", "sludge", "thick_sludge", "trap"]
     establish_connection adapter: "sqlite3", database: "warriors/map_survey.db"
     connection.create_table :notes, if_not_exists: true do |t|
       t.column :level_number, :int, limit: 3, :null => false
-      t.column :unit_type, :string, limit: 20, :null => false
+      t.column :unit_type, :unit_type, :null => false
       t.column :x, :int, limit:3, :null => false
       t.column :y, :int, limit:3, :null => false
     end

--- a/towers/clio/level_004.rb
+++ b/towers/clio/level_004.rb
@@ -1,11 +1,16 @@
 #  -------
 # |    .  |
-# |@   G >|
+# |@   g >|
 # |    .  |
 #  -------
 
 description "The vacation castle is in sight, but it is guarded. That guard looks .... strong."
-tip "The guard will only let you through if you have collected the survey data the King demands"
+tip <<-TEXT
+The guard will only let you through if you have collected the survey data the King demands. 
+The guard will want to look at your records, so you better write them with ActiveRecord.
+
+Lucky for you, the King has provided you with a template, that you can see in the .db file
+TEXT
 
 time_bonus 20 #TODO: Refine
 ace_score 19 #TODO: Refine


### PR DESCRIPTION
Note: I'm struggling a bit with the DB definition aspect.
Especially the type. It's now a string, but ideally we'd want that to be a FK to a reference table listing all the possible (valid) types. So that the player needs to make sure to insert valid values, and has to look for them first.


The notes can be written like this:
RubyWarrior::Note.new(level_number: 4, unit_type: 'warrior', x: 1, y: 0).save!